### PR TITLE
fix: hyperchain nodes require child_block_production_time set

### DIFF
--- a/src/lib/aeternityConfig.ts
+++ b/src/lib/aeternityConfig.ts
@@ -123,6 +123,7 @@ export function genAeternityConf(
             rewards_contract: mainStaking.init.pubkey,
             child_block_time: conf.childBlockTime,
             child_epoch_length: conf.childEpochLength,
+            child_block_production_time: conf.childBlockProductionTime,
             pinning_reward_value: conf.pinningReward,
             fixed_coinbase: conf.fixedCoinbase,
             default_pinning_behavior: conf.enablePinning,

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -10,6 +10,7 @@ export const InitConfig = z.object({
   networkId: z.string(),
   childBlockTime: z.bigint(),
   childEpochLength: z.bigint(),
+  childBlockProductionTime: z.bigint(),
   pinningReward: z.bigint(),
   fixedCoinbase: z.bigint(),
   enablePinning: z.boolean(),
@@ -31,34 +32,33 @@ export const InitConfig = z.object({
 
 export type InitConfig = z.infer<typeof InitConfig>;
 
-export const defaultInitConf = (networkId: string): InitConfig => {
-  return {
-    networkId,
-    childBlockTime: 3000n,
-    // should be ~10 parent blocks in child blocks
-    // in case of 180s block time of AE and 3s block time of the child chain
-    // 180s * 10 = 1800/3 = 600
-    childEpochLength: 600n,
-    pinningReward: BigInt(toAettos(1000)),
-    fixedCoinbase: BigInt(toAettos(100)),
-    enablePinning: true,
-    parentChain: {
-      type: "AE2AE",
-      networkId: "ae_uat",
-      nodeURL: getParentNodeURL("ae_uat"),
-      epochLength: 10n,
-    },
-    validators: {
-      count: 3n,
-      balance: 3100000000000000000000000000n,
-      validatorMinStake: BigInt(toAettos(1_000_000)),
-    },
-    treasuryInitBalance: 1000000000000000000000000000000000000000000000000n,
-    faucetInitBalance: 1000000000000000000000000000n,
-    contractSourcesPrefix:
-      "https://raw.githubusercontent.com/aeternity/aeternity/refs/tags/v7.3.0-rc3/",
-  };
-};
+export const defaultInitConf = (networkId: string): InitConfig => ({
+  networkId,
+  childBlockTime: 3000n,
+  // should be ~10 parent blocks in child blocks
+  // in case of 180s block time of AE and 3s block time of the child chain
+  // 180s * 10 = 1800/3 = 600
+  childEpochLength: 600n,
+  childBlockProductionTime: 500n,
+  pinningReward: BigInt(toAettos(1000)),
+  fixedCoinbase: BigInt(toAettos(100)),
+  enablePinning: true,
+  parentChain: {
+    type: "AE2AE",
+    networkId: "ae_uat",
+    nodeURL: getParentNodeURL("ae_uat"),
+    epochLength: 10n,
+  },
+  validators: {
+    count: 3n,
+    balance: 3100000000000000000000000000n,
+    validatorMinStake: BigInt(toAettos(1_000_000)),
+  },
+  treasuryInitBalance: 1000000000000000000000000000000000000000000000000n,
+  faucetInitBalance: 1000000000000000000000000000n,
+  contractSourcesPrefix:
+    "https://raw.githubusercontent.com/aeternity/aeternity/refs/tags/v7.3.0-rc3/",
+});
 
 export const initFilePath = (dir: string) => path.join(dir, "init.yaml");
 


### PR DESCRIPTION
when starting with a fresh config, it errors with:

{{missing_mandatory_chain_consensus_config_key,[<<"child_block_production_time">>]},

after filling this value in manually it continues on. 500 is the default value from the schema, so figure it's safe to use as the default here.