### PR TITLE
child_block_production_time default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ See the [Aeternity Node Documentation](https://github.com/aeternity/aeternity/tr
 The tool generates a default configuration in `init.yaml`:
 
 ```yaml
+childBlockProductionTime: 500
 childBlockTime: 3000
 childEpochLength: 600
 enablePinning: true

--- a/src/lib/configSchema/aeternity_config_schema.json
+++ b/src/lib/configSchema/aeternity_config_schema.json
@@ -1735,10 +1735,6 @@
                                             "default": 500,
                                             "type": "integer"
                                         },
-                                        "child_block_production_time": {
-                                            "description": "The time in milliseconds to produce a child block",
-                                            "type": "integer"
-                                        },
                                         "child_epoch_length": {
                                             "description": "The number of blocks in an epoch on the child chain",
                                             "type": "integer"

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -9,6 +9,7 @@ import { getParentNodeURL } from "./aeParent.js";
 export const InitConfig = z.object({
   networkId: z.string(),
   childBlockTime: z.bigint(),
+  childBlockProductionTime: z.bigint(),
   childEpochLength: z.bigint(),
   pinningReward: z.bigint(),
   fixedCoinbase: z.bigint(),
@@ -35,6 +36,7 @@ export const defaultInitConf = (networkId: string): InitConfig => {
   return {
     networkId,
     childBlockTime: 3000n,
+    childBlockProductionTime: 500n,
     // should be ~10 parent blocks in child blocks
     // in case of 180s block time of AE and 3s block time of the child chain
     // 180s * 10 = 1800/3 = 600


### PR DESCRIPTION
Fixes remaining core issue from #7 , was not addressed in update from PR #8 .

The config that is generated still does not contain the required `child_block_production_time` key and new hyperchain configurations fail to start on a node without this part in place.